### PR TITLE
Added bullet about custom blocks

### DIFF
--- a/knowledge/1.16-changes.md
+++ b/knowledge/1.16-changes.md
@@ -57,6 +57,7 @@ What exactly changed in 1.16? This document will attempt an overview of the know
 ## Miscellaneous Broken Stuff
  - Addrider with Behavior Pack animations is broken.
  - `on_interact` with ridden entities is broken.
+ - Custom blocks can no longer be registered to the creative inventory using `register_to_creative_menu`.
 
 ## Miscellaneous New Features
  - `"loop"` attribute of client side animations has new option `"hold_on_last_frame"`


### PR DESCRIPTION
Custom blocks can no longer be added to the creative inventory as of 1.16.0.