### PR TITLE
Add sticky table of contents

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -19,7 +19,7 @@
         .highlight .s2 {
             color: #ce9178;
         }
-        .highlight .mi {
+        .highlight .mi, .highlight .mf {
             color: #b5cea8;
         }
         .highlight .kc {
@@ -45,7 +45,7 @@
         .highlight .s2 {
             color: #ce9178;
         }
-        .highlight .mi {
+        .highlight .mi, .highlight .mf {
             color: #b5cea8;
         }
         .highlight .kc {
@@ -128,4 +128,23 @@
         }
         document.getElementsByClassName("site-footer")[0].prepend(switcher);
     });
+
+    window.addEventListener('DOMContentLoaded', () => {
+        const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                const id = entry.target.getAttribute('id');
+                if (entry.intersectionRatio > 0) {
+                    document.querySelector(`#toc li a[href="#${id}"]`).parentElement.classList.add('active');
+                } else {
+                    document.querySelector(`#toc li a[href="#${id}"]`).parentElement.classList.remove('active');
+                }
+            });
+        });
+        document.querySelectorAll('h1[id], h2[id]').forEach((section) => {
+            observer.observe(section);
+        });
+
+    });
+
+
 </script>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -15,3 +15,51 @@
   background-size: 1.5em 1.5em;
   background-repeat: no-repeat;
 }
+
+@media (min-width: 93rem) {
+  #toc {
+    position: fixed;
+    top: calc(60px + 2rem);
+    left: calc((100% - 1064px) / 2 + 1064px);
+    border-left: 1px solid $border-color;
+    max-width: calc(100% - ((100% - 1064px) / 2 + 1092px));
+    overflow-y: auto;
+    max-height: calc(100% - 60px - 2rem);
+    padding-left: 12px;
+  }
+
+  #toc ul, #toc ol {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  #toc li {
+    margin-left: 1rem;
+  }
+
+  #toc li.active > a {
+    color: mix($body-background-color, $body-text-color, 10%);
+    font-weight: 500;
+  }
+
+  #toc a {
+    background: none;
+    text-decoration: none;
+    display: block;
+    padding: .125rem 0;
+    color: mix($body-background-color, $body-text-color, 70%);
+    transition: all 50ms ease-in-out;
+  }
+
+  #toc a:hover,
+  #toc a:focus {
+    color: $body-text-color;
+  }
+  #toc ol > li::before {
+    content: none;
+  }
+}
+
+#toc > ol > li > ol > li > ol {
+  display: none;
+}

--- a/knowledge/troubleshooting.md
+++ b/knowledge/troubleshooting.md
@@ -6,13 +6,13 @@ parent: Knowledge
 
 # Entity Troubleshooting
 
-<details closed markdown="block">
-    <summary>
-      Table of contents [Click to Show]
-    </summary>
-    {: .text-delta }
-  1. TOC
-  {:toc}
+<details id="toc" open markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+1. TOC
+{:toc}
 </details>
 
 Creating Addons for Minecraft is a fairly easy process *once you get a hang of it*. The first time is usually a difficult, bug-prone process. This document contains some tips and tricks for fixing those dastardly bugs, as well as best practice information.


### PR DESCRIPTION
Every page, which should display new Table of Contents, needs to include this:
```
<details id="toc" open markdown="block">
  <summary>
    Table of contents
  </summary>
  {: .text-delta }
1. TOC
{:toc}
</details>
```

Basically it's the same TOC as always, but with id "toc".