### PR TITLE
Fix issues with Commands Tutorial

### DIFF
--- a/tutorials/beginner-commands.md
+++ b/tutorials/beginner-commands.md
@@ -8,7 +8,7 @@ parent: Tutorials
 
 <details id="toc" open markdown="block">
   <summary>
-    Table of contents
+    Table of Contents
      
   </summary>
   {: .text-delta }
@@ -18,13 +18,10 @@ parent: Tutorials
 
 
 
-# Command Tutorial
-##### Written by VideoCarp<br>
+# Beginning
+Written by VideoCarp<br>
 
-<div align="center">
-      <img src="https://img.shields.io/badge/6%20minutes%2058%20seconds-estimated%20read%20time-green">
-</div>
-
+Estimated Read Time: 6:58 (minutes)<br>
 Firstly, since you're new I recommend **reading to full**.<br>
 <br>
 ### What are commands?
@@ -49,11 +46,8 @@ Here are some of the basics, read above for a bit of how to read this.
 A block is essentially an object that takes up a 1x1 space. An example of a block would be say grass, dirt, etc.<br>
 Everything in the below image is a block, don't worry about the water just yet.<br>
 <br>
-<div align="center">
 
 ![grassblock](https://i.ibb.co/TqZjJ4m/FBB40-ECF-D2-F9-476-D-B56-B-1-EAA3-C6-D5-E08.png)<br>
-
-</div>
 
 #### What is an entity?
 ---------------------
@@ -62,11 +56,7 @@ Water isn't fixed to it's position, is it an entity? No, the reason for that is 
 **All mobs, but not only mobs** are entities.
 Below is an example of an entity.<br>
 
-<span align="center">
-
 ![chicken.png](https://i.ibb.co/DGbPNgQ/Webp-net-resizeimage.png)<br>
-
-</span>
 
 <br>
 <br>
@@ -194,10 +184,10 @@ For example, a file named `cool_file.mcfunction` will execute if you return the 
 Now for the folder setup.<br>
 <br>
 Bedrock Edition:
-<span style="color: #ff0000"></span>
 
-> `(your pack name)`:open_file_folder:<br>
-> > `(functions)`:open_file_folder:, [`<manifest.json>`📄](https://wiki.bedrock.dev/guide/manifest-function-extension.html#manifests) , `<pack_icon.png>`📄<br>
-> > > `<filename.mcfunction>`:page_facing_up: <br>
+> `(your pack name)`📂<br>
+> `<pack_icon.png>`📄<br>
+> > `(functions)`📂, [`<manifest.json>`📄](https://wiki.bedrock.dev/guide/manifest-function-extension.html#manifests) , `<pack_icon.png>`📄<br>
+> > > `<filename.mcfunction>`📄<br>
 
 Here are [some open-source examples](https://github.com/VideoCarp/carpcorps/tree/master/function_packs) of raw commands.


### PR DESCRIPTION
Fixed display issues in this file:
- Read-time badge removed.
- Renamed first and second header, to make more sense.
- Converted “Written by VideoCarp” header to text, to fix TOC.
- Removed  `</span>` that displayed at entity example.
- Put the unicode emojis, markdown didn’t display.