### PR TITLE
Added minecraft:wither_skull_dangerous identifier

### DIFF
--- a/documentation/runtime-identifier.md
+++ b/documentation/runtime-identifier.md
@@ -109,3 +109,12 @@ Perfect for imitating a block, as long as the player is in Adventure Mode.
 ---
 ## minecraft:panda
  - Allows `query.is_grazing` and `query.sit_mount` to function with the `minecraft:behavior.random_sitting` component
+
+---
+## minecraft:wither_skull_dangerous
+ - Makes the entity drop a wither rose on death
+ - Any entity killed by the entity will have a wither rose placed where it dies. Strangely, zombies seem to drop the wither rose instead of having it placed at the spot they die at.
+ - Makes the entity constantly generate particles(the identifier of the particles it generates is `minecraft:basic_smoke_particle`)
+ - Makes the entity unaffected by gravity(this seems to cause entites with `minecraft:projectile` to move in a straight line)
+ - Prevents the entity from taking damage
+ - only works for entities with no ai goals(so it's only useful for dummy entities and projectiles)


### PR DESCRIPTION
With some messing around, I realized that minecraft:wither_skull_dangerous is a runtime identifier, with all of the effects I noted in the description for it. 