### PR TITLE
Found a typo, it made me confuse ngl

### DIFF
--- a/guide/custom-blocks.md
+++ b/guide/custom-blocks.md
@@ -73,7 +73,7 @@ You can play around with changing the component values for each of these. Now le
 # Block Resource File
 The resource definition for blocks differs from entities/items, because all the definitions appear in a single file.
 
-{% include filepath.html path="BP/blocks.json"%}
+{% include filepath.html path="RP/blocks.json"%}
 ```jsonc
 {
     "format_version": [


### PR DESCRIPTION
Found a typo on this page when I was checking on how to make a block, I followed the instructions and made the addon buggy, it made all items into white and blocks to white. Its because 
![image](https://user-images.githubusercontent.com/68810085/103174547-0b817c00-489e-11eb-8e9d-33d971dac25d.png) I placed them on Bp lmao. should be in rp 

![image](https://user-images.githubusercontent.com/68810085/103174595-703cd680-489e-11eb-8677-4a3d4fd88c4a.png)
