### PR TITLE
Fix some image links and add pixelated css class

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -317,3 +317,11 @@ input {
   color: #555;
   font: 95% Arial, Helvetica, sans-serif;
 }
+
+/*
+  Pixelated images
+*/
+
+img.pixelated {
+  image-rendering: pixelated;
+}

--- a/guide/custom-blocks.md
+++ b/guide/custom-blocks.md
@@ -124,18 +124,18 @@ These "gorgeous" textures are the ones I'm going to use for my example blocks. T
 
 *Left to right: `blocky.png`, `sapp_log_side.png`, `side_block_top.png`, `sb_up.png`, `sb_down.png`, `sb_north.png`, `sb_south.png`, `sb_west.png`, `sb_east.png`*
 
-![](/assets/guide/tut_blocky_texture.png)
+![](/assets/guide/tut_blocky_texture.png){: .pixelated}
 
-![](/assets/guide/tut_log_side_texture.png)
-![](/assets/guide/tut_log_top_texture.png)
+![](/assets/guide/tut_log_side_texture.png){: .pixelated}
+![](/assets/guide/tut_log_top_texture.png){: .pixelated}
 
-![](/assets/guide/tut_sb_up.png)
-![](/assets/guide/tut_sb_down.png)
+![](/assets/guide/tut_sb_up.png){: .pixelated}
+![](/assets/guide/tut_sb_down.png){: .pixelated}
 
-![](/assets/guide/tut_sb_north.png)
-![](/assets/guide/tut_sb_south.png)
-![](/assets/guide/tut_sb_west.png)
-![](/assets/guide/tut_sb_east.png)
+![](/assets/guide/tut_sb_north.png){: .pixelated}
+![](/assets/guide/tut_sb_south.png){: .pixelated}
+![](/assets/guide/tut_sb_west.png){: .pixelated}
+![](/assets/guide/tut_sb_east.png){: .pixelated}
 
 
 All textures need to be defines a **shortname**, (and we'll do it the same way as we defined item texture shortnames in `RP/textures/item_texture.json`), but this time in `RP/textures/terrain_texture.json`

--- a/guide/custom-particles.md
+++ b/guide/custom-particles.md
@@ -69,7 +69,7 @@ File structure:
 - "texture" defines the texture file. Not that a single image file can hold textures for many particles.
 - "material" is usually set to "particles_alpha" for particles.
 
-![](/assets/guide/custom_particles_5.png){:height="100px" width="100px"}
+![](/assets/guide/custom_particles_5.png){:height="100px" width="100px" .pixelated}
 
 That is the texture I'm going to use, it's size is 16*16. (`RP/particles/tut_particles.png`). As you can see, it has 4 different textures in it, each of them being a 8*8. The upper row (*starting/top left corner at at 0, 0*) is the flipbook texture for "tut:curvy_particle" and the bottom row (*top left corner at/starting at 0, 8*). We'll define this in the "billboard_texture" component.
 

--- a/guide/project-setup.md
+++ b/guide/project-setup.md
@@ -136,9 +136,9 @@ The next step is, naturally, creating your `BP/manifest.json`. it is very much l
 ```
 
 The last thing to do is to add your `pack_icon.png` file to both the BP and RP folders. I'm going to use this image here for the BP:
-![Pack icon](/assets/guide/pack_icon_BP.png)
+![Pack icon](/assets/guide/pack_icon_BP.png){: .pixelated}
 And this one for the RP:
-![Pack icon](/assets/guide/pack_icon_RP.png)
+![Pack icon](/assets/guide/pack_icon_RP.png){: .pixelated}
 
 
 If you have done everything correctly, your packs should show up in Minecraft now!
@@ -161,7 +161,7 @@ Now to create a testing world to test your new add-on!
 ![](/assets/guide/world_params_3.jpg)
 
 Now activate your behavior pack. If you haven't set up dependencies in the manifest, apply your resource pack too, otherwise, it'll be applied automatically). Check if **[EX]**(Experimental Gameplay) is turned on, and click '**Create**'. You might need a separate '*Infinite*' world to test entity spawning too.
-![](/assets/guide/behavior_pack_applied.jpg)
+![](/assets/guide/behavior_pack_applied.png)
 
 _____________
 ___

--- a/tutorials/entity-holds-item.md
+++ b/tutorials/entity-holds-item.md
@@ -76,4 +76,4 @@ To have the entity always spawn with the same item, add the following loot table
 
 If everything went well, you'll have something looking like this:
 
-![](/assets/images/tutorials/finished_result.png)
+![](/assets/images/tutorials/entity-holds-item/finished_result.png)


### PR DESCRIPTION
Fixed a couple of image links that were broken in guide/project-setup and tutorials/entity-holds-item. 
Added a `.pixelated` scss class in custom.scss and added the class to several images in the guide. 