### PR TITLE
Replaced the ES File Explorer with Acode Editor

### DIFF
--- a/guide/software-preparation.md
+++ b/guide/software-preparation.md
@@ -45,7 +45,7 @@ Editor recommendations are starred.
 - [_CoreCoder (Free)_](https://hanprog.itch.io/core-coder-one) - is a unique Code Editor developed specifically for Addon creation with JSON linting and autocomplete.   
 
 ### Mobile Alternatives
-- **Android**: [_ES File Explorer_](https://play.google.com/store/apps/details?id=com.File.Manager.Filemanager&hl=de&gl=US)
+- **Android**: [_ACode Editor_](https://play.google.com/store/apps/details?id=com.foxdebug.acodefree)
 - **iOS**: [_Kodex_](https://apps.apple.com/us/app/kodex/id1038574481)
 
 

--- a/knowledge/useful-links.md
+++ b/knowledge/useful-links.md
@@ -112,4 +112,4 @@ Important links have a ⭐.
  - [Block Models](https://blockmodels.com/)
  - [Bedrock Addons Reddit](https://www.reddit.com/r/BedrockAddons/)
  - [Minecraft Marketplace Stats](https://mcmarketstats.miste.fr/globalStats/)
- - [Addon Obfuscator](https://pixelpoly.co/creator-tools/obfuscator)
+ - [Addon Obfuscator](https://tools.pixelpoly.co/obfuscator)


### PR DESCRIPTION
I updated the software preparation page in guide section by replacing ES File Explorer with Acode Editor as a preferred code editor for making add-ons on Android devices and also also updated Addon obfuscator link