### PR TITLE
fix example download links

### DIFF
--- a/guide/download-packs.md
+++ b/guide/download-packs.md
@@ -17,7 +17,7 @@ badge_justification: left
 To get the most out of the guide, you should always attempt all guide-exercises yourself! However if you get very stuck, the example packs should give you some valuable reference material.
 
 Download here: 
- - <a href="assets/packs/guide_RP.zip?raw=true">Resource Pack Download</a>
- - <a href="zips/guide_BP.zip?raw=true">Behavior Pack Download</a>.
+ - <a href="/assets/packs/guide/guide_RP.zip?raw=true">Resource Pack Download</a>
+ - <a href="/assets/packs/guide/guide_BP.zip?raw=true">Behavior Pack Download</a>.
 
 To install, simply unzip the behavior pack into the Minecraft folder: `com.mojang\development_behavior_packs` or `com.mojang\development_resource_packs`, depending on which pack you downloaded.


### PR DESCRIPTION
I kept the querystring raw=true because I assume that is there for a reason.