### PR TITLE
Add query.movement_direction information

### DIFF
--- a/documentation/queries.md
+++ b/documentation/queries.md
@@ -235,3 +235,17 @@ Returns the offset factor for the player's rightarm bone compared to the default
 # variable.short_arm_offset_left 
 
 Identical behavior to `variable.short_arm_offset_right` except it references the player leftarm bone.
+
+# query.movement_direction
+
+Essentially, returns the ratio between speed in the specified argument, over the total speeds in all 3 axis combined. For example, you are moving 5 blocks/second in the x-axis, 0 blocks/second in the y-axis, and 3 blocks/second in the z-axis -> `5 / ( 5 + 0 + 3 ) = 0.625`.
+
+| Argument | Axis |
+|----------|------|
+| 0        | X    |
+| 1        | Y    |
+| 2        | Z    |
+
+If stationary, the values will return as `0`. When you are moving along the positive X/Y/Z axis, the returned value is positive. If you are moving in the opposite direction, the returned value is negative. The return value should never exceed `1` or `-1`.
+
+It's worth noting that the `Y` axis may not work as expected. When you stay in the same spot, and are not hovering, the query returns `-1`. When you stay on the same X and Z coordinates and move downwards on the Y axis, the query also returns `-1`. If you are hovering on a constant Y coordinate, it returns `0`.


### PR DESCRIPTION
A minor addition to the queries documentation. Simply added some gathered information about `query.movement_direction`, and added that.