### PR TITLE
Updated Content log settings path

### DIFF
--- a/troubleshooting/index.md
+++ b/troubleshooting/index.md
@@ -23,7 +23,7 @@ The best way to prevent *invisible entity syndrome* and other nasty bugs is by s
 
 ## Content Log
 
-The next thing you should do is turn on your content log. This can be done like: `Settings > Profile > Enable Content Log GUI`. Then press `ctrl+h` in-game to see any errors or output that might pop-up. Errors in the content log will show up every time you open the world, and also during gameplay if more errors occur.
+The next thing you should do is turn on your content log. This can be done like: `Settings > Creator > Enable Content Log GUI`. Then press `ctrl+h` in-game to see any errors or output that might pop-up. Errors in the content log will show up every time you open the world, and also during gameplay if more errors occur.
 
 {% include info.html
   contents='Errors are not cleared between runs, so it is possible the errors you see in the content log are *old* errors, from prior runs.'


### PR DESCRIPTION
With 1.17, the settings for the content log have been moved to a new tab, creator settings.